### PR TITLE
isLast and isAfterLast checking removed for TYPE_FORWARD_ONLY ResultSet

### DIFF
--- a/src/main/kotlin/com/vladsch/kotlin/jdbc/Rows.kt
+++ b/src/main/kotlin/com/vladsch/kotlin/jdbc/Rows.kt
@@ -21,7 +21,7 @@ class Rows(rs: ResultSet) : Row(rs), Sequence<Row> {
     }
 
     fun hasNext(): Boolean {
-        if (rs.isClosed || rs.isLast || rs.isAfterLast) return false
+        if (rs.isClosed || (rs.type != ResultSet.TYPE_FORWARD_ONLY && (rs.isLast || rs.isAfterLast))) return false
         if (movedNext) return true
 
         movedNext = rs.next()


### PR DESCRIPTION
Support for the isLast and isAfterLast methods are optional and up to the vendor for the ResultSets of type TYPE_FORWARD_ONLY.