### PR TITLE
Fix SqlQuery session.list vs model.list differences

### DIFF
--- a/src/main/kotlin/com/vladsch/kotlin/jdbc/Helpers.kt
+++ b/src/main/kotlin/com/vladsch/kotlin/jdbc/Helpers.kt
@@ -95,6 +95,14 @@ fun sqlQuery(statement: String, inputParams: Map<String, Any?>): SqlQuery {
     return SqlQuery(statement, inputParams = inputParams)
 }
 
+fun sqlQuery(statement: String, inputParams: Map<String, Any?>, params: List<Any?>): SqlQuery {
+    return SqlQuery(statement, params = params, inputParams = inputParams)
+}
+
+fun sqlQuery(statement: String, inputParams: Map<String, Any?>, vararg params: Any?): SqlQuery {
+    return SqlQuery(statement, params = params.toList(), inputParams = inputParams)
+}
+
 fun sqlCall(statement: String, vararg params: Any?): SqlCall {
     return SqlCall(statement, params = params.toList())
 }


### PR DESCRIPTION
This fixes the differences in `session.list` vs `model.list` due to an issue with the SqlQuery overloads, that when given a map and a list, would turn it all into a list, rather than passing them separately. This adds new overloads that will fix that, giving the expected results for `model.list`.